### PR TITLE
Update Benqi comptroller

### DIFF
--- a/src/abis/BenqiComptroller.json
+++ b/src/abis/BenqiComptroller.json
@@ -54,6 +54,31 @@
             "anonymous": false,
             "inputs": [
                 {
+                    "indexed": false,
+                    "internalType": "uint8",
+                    "name": "rewardToken",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "contract QiToken",
+                    "name": "qiToken",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint256",
+                    "name": "newBorrowRewardSpeed",
+                    "type": "uint256"
+                }
+            ],
+            "name": "BorrowRewardSpeedUpdated",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
                     "indexed": true,
                     "internalType": "address",
                     "name": "contributor",
@@ -383,7 +408,7 @@
                 {
                     "indexed": false,
                     "internalType": "uint8",
-                    "name": "tokenType",
+                    "name": "rewardToken",
                     "type": "uint8"
                 },
                 {
@@ -395,11 +420,11 @@
                 {
                     "indexed": false,
                     "internalType": "uint256",
-                    "name": "newSpeed",
+                    "name": "newSupplyRewardSpeed",
                     "type": "uint256"
                 }
             ],
-            "name": "SpeedUpdated",
+            "name": "SupplyRewardSpeedUpdated",
             "type": "event"
         },
         {
@@ -441,7 +466,7 @@
             "constant": false,
             "inputs": [
                 {
-                    "internalType": "address payable",
+                    "internalType": "address",
                     "name": "recipient",
                     "type": "address"
                 },
@@ -684,7 +709,12 @@
                 },
                 {
                     "internalType": "uint256",
-                    "name": "rewardSpeed",
+                    "name": "supplyRewardSpeed",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "borrowRewardSpeed",
                     "type": "uint256"
                 }
             ],
@@ -901,6 +931,32 @@
                     "internalType": "bool",
                     "name": "",
                     "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "borrowRewardSpeeds",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
                 }
             ],
             "payable": false,
@@ -1865,32 +1921,6 @@
                     "internalType": "address",
                     "name": "",
                     "type": "address"
-                }
-            ],
-            "name": "rewardSpeeds",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "payable": false,
-            "stateMutability": "view",
-            "type": "function"
-        },
-        {
-            "constant": true,
-            "inputs": [
-                {
-                    "internalType": "uint8",
-                    "name": "",
-                    "type": "uint8"
-                },
-                {
-                    "internalType": "address",
-                    "name": "",
-                    "type": "address"
                 },
                 {
                     "internalType": "address",
@@ -2045,6 +2075,32 @@
             "outputs": [],
             "payable": false,
             "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "internalType": "uint8",
+                    "name": "",
+                    "type": "uint8"
+                },
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "supplyRewardSpeeds",
+            "outputs": [
+                {
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
             "type": "function"
         },
         {

--- a/src/entities/comptroller.ts
+++ b/src/entities/comptroller.ts
@@ -62,8 +62,8 @@ export class Comptroller {
                     const qiTokenContract: Contract = new Contract(qiOrCToken.address, contracts.IQiToken.abi, provider);
                     var supplySpeedForQi: BN, supplySpeedForAvax: BN, totalSupply: BN;
                     var promises = [];
-                    promises.push(comptrollerContract.rewardSpeeds(BenqiRewardTypes.Qi, qiOrCToken.address).then((res: BN) => supplySpeedForQi = res));
-                    promises.push(comptrollerContract.rewardSpeeds(BenqiRewardTypes.Avax, qiOrCToken.address).then((res: BN) => supplySpeedForAvax = res));
+                    promises.push(comptrollerContract.supplyRewardSpeeds(BenqiRewardTypes.Qi, qiOrCToken.address).then((res: BN) => supplySpeedForQi = res));
+                    promises.push(comptrollerContract.supplyRewardSpeeds(BenqiRewardTypes.Avax, qiOrCToken.address).then((res: BN) => supplySpeedForAvax = res));
                     promises.push(qiTokenContract.totalSupply().then((res: BN) => totalSupply = res));
                     await Promise.all(promises);
 

--- a/src/entities/oneClickWrapper.ts
+++ b/src/entities/oneClickWrapper.ts
@@ -1296,7 +1296,7 @@ export class OneClickWrapper {
                     action: action
                 }
             })
-            console.log(requesturl)
+            // console.log(requesturl)
             const data: WrapperAPRInfo = await axios.get(requesturl).then((res: any) => res.data);
             return data;
         }


### PR DESCRIPTION
BenQi very recently updated their Comptroller contract implementation (see transactions [1](https://dashboard.tenderly.co/tx/ava/0xbb57ff5fe1eb305ec31de5e788bbe1e8e184c05a99810c029c483cf725821dd0) and [2](https://dashboard.tenderly.co/tx/ava/0xf52e1bad745da61d635e4b7fe22eaeeb10a87c350540deceddc15b52a4fe9951) here) where there is no longer a `rewardSpeeds` mapping. Instead, this has been replaced with separate `supplyRewardSpeeds` and `borrowRewardSpeeds` mappings.

In light of this change, `rewardSpeeds` has been replaced with `supplyRewardSpeeds`.